### PR TITLE
Temporarily restrict to 2.4G Wi-Fi on 5G-capable SoCs

### DIFF
--- a/wifi_configuration_ap.cc
+++ b/wifi_configuration_ap.cc
@@ -155,6 +155,11 @@ void WifiConfigurationAp::StartAccessPoint()
     ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
     ESP_ERROR_CHECK(esp_wifi_start());
 
+#ifdef CONFIG_SOC_WIFI_SUPPORT_5G
+    // Temporarily use only 2.4G Wi-Fi.
+    ESP_ERROR_CHECK(esp_wifi_set_band_mode(WIFI_BAND_MODE_2G_ONLY));
+#endif
+
     ESP_LOGI(TAG, "Access Point started with SSID %s", ssid.c_str());
 }
 


### PR DESCRIPTION
ESP32C5 支持 5G Wi-Fi。由于 5G 信道较多，完整扫描耗时较长，如果后台定期全信道扫描可能会影响用户体验，故暂时将 Wi-Fi 设置为仅 2.4G 模式。