### PR TITLE
fix: In version 5.4 compilation error missing esp_timer issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ idf_component_register(
         "assets/wifi_configuration.html"
         "assets/wifi_configuration_done.html"
     REQUIRES
+    	"esp_timer"
         "esp_http_server"
         "esp_wifi"
         "nvs_flash"


### PR DESCRIPTION
修复在ESPIDF5.4中编译报错，fatal error: esp_timer.h: No such file or directory