### PR TITLE
Get the mac address function from ESP32-P4 via esp_hosted

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -8,4 +8,4 @@ files:
 license: MIT
 repository: https://github.com/78/esp-wifi-connect
 url: https://github.com/78/esp-wifi-connect
-version: 2.3.2
+version: 2.3.3

--- a/wifi_configuration_ap.cc
+++ b/wifi_configuration_ap.cc
@@ -104,7 +104,11 @@ std::string WifiConfigurationAp::GetSsid()
 {
     // Get MAC and use it to generate a unique SSID
     uint8_t mac[6];
+#if CONFIG_IDF_TARGET_ESP32P4
+    esp_wifi_get_mac(WIFI_IF_AP, mac);
+#else
     ESP_ERROR_CHECK(esp_read_mac(mac, ESP_MAC_WIFI_SOFTAP));
+#endif
     char ssid[32];
     snprintf(ssid, sizeof(ssid), "%s-%02X%02X", ssid_prefix_.c_str(), mac[4], mac[5]);
     return std::string(ssid);
@@ -118,9 +122,6 @@ std::string WifiConfigurationAp::GetWebServerUrl()
 
 void WifiConfigurationAp::StartAccessPoint()
 {
-    // Get the SSID
-    std::string ssid = GetSsid();
-
     // Initialize the TCP/IP stack
     ESP_ERROR_CHECK(esp_netif_init());
 
@@ -141,6 +142,9 @@ void WifiConfigurationAp::StartAccessPoint()
     // Initialize the WiFi stack in Access Point mode
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+    // Get the SSID
+    std::string ssid = GetSsid();
 
     // Set the WiFi configuration
     wifi_config_t wifi_config = {};


### PR DESCRIPTION
Adjust the ESP32-P4 compilation to obtain the mac address function, and obtain it through the esp_wifi_remote component function.

Adjust the position of the logic function for obtaining WIFI ssid to prevent conflicts