### PR TITLE
解决 vivo 手机连接 wifi 不能自动跳转问题

### DIFF
--- a/wifi_configuration_ap.cc
+++ b/wifi_configuration_ap.cc
@@ -466,7 +466,7 @@ void WifiConfigurationAp::StartWebServer()
     // Register all common captive portal detection endpoints
     const char* captive_portal_urls[] = {
         "/hotspot-detect.html",    // Apple
-        "/generate_204",           // Android
+        "/generate_204*",           // Android
         "/mobile/status.php",      // Android
         "/check_network_status.txt", // Windows
         "/ncsi.txt",              // Windows


### PR DESCRIPTION
发现 vivo 手机的探测地址在 `/generate_204` 后面有一个随机的 uuid  后缀，url 加上通配符就可以自动跳转了。

W (16507) httpd_uri: httpd_uri: URI '/generate_204_59e0eb23-6212-4322-bdd5-bbf5859c48cc' not found
W (16507) httpd_txrx: httpd_resp_send_err: 404 Not Found - Nothing matches the given URI