### PR TITLE
WiFi: select strongest signal when multiple APs with same SSID exist

### DIFF
--- a/include/wifi_station.h
+++ b/include/wifi_station.h
@@ -23,6 +23,7 @@ struct WifiApRecord {
     int channel;
     wifi_auth_mode_t authmode;
     uint8_t bssid[6];
+    bool has_multiple_same_ssid;
 };
 
 /**

--- a/wifi_station.cc
+++ b/wifi_station.cc
@@ -173,25 +173,30 @@ void WifiStation::HandleScanResult() {
 
     auto& ssid_manager = SsidManager::GetInstance();
     auto ssid_list = ssid_manager.GetSsidList();
-    for (int i = 0; i < ap_num; i++) {
-        auto ap_record = ap_records[i];
-        auto it = std::find_if(ssid_list.begin(), ssid_list.end(), [ap_record](const SsidItem& item) {
-            return strcmp((char *)ap_record.ssid, item.ssid.c_str()) == 0;
-        });
-        if (it != ssid_list.end()) {
+
+    for (const auto& ssid_item : ssid_list) {
+        wifi_ap_record_t *best_ap = nullptr;
+        for (int i = 0; i < ap_num; i++) {
+            if (strcmp((char *)ap_records[i].ssid, ssid_item.ssid.c_str()) == 0) {
+                if (best_ap == nullptr || ap_records[i].rssi > best_ap->rssi) {
+                    best_ap = &ap_records[i];
+                }
+            }
+        }
+        if (best_ap != nullptr) {
             ESP_LOGI(TAG, "Found AP: %s, BSSID: %02x:%02x:%02x:%02x:%02x:%02x, RSSI: %d, Channel: %d, Authmode: %d",
-                (char *)ap_record.ssid, 
-                ap_record.bssid[0], ap_record.bssid[1], ap_record.bssid[2],
-                ap_record.bssid[3], ap_record.bssid[4], ap_record.bssid[5],
-                ap_record.rssi, ap_record.primary, ap_record.authmode);
+                (char *)best_ap->ssid, 
+                best_ap->bssid[0], best_ap->bssid[1], best_ap->bssid[2],
+                best_ap->bssid[3], best_ap->bssid[4], best_ap->bssid[5],
+                best_ap->rssi, best_ap->primary, best_ap->authmode);
             WifiApRecord record = {
-                .ssid = it->ssid,
-                .password = it->password,
-                .channel = ap_record.primary,
-                .authmode = ap_record.authmode,
+                .ssid = ssid_item.ssid,
+                .password = ssid_item.password,
+                .channel = best_ap->primary,
+                .authmode = best_ap->authmode,
                 .bssid = {0}
             };
-            memcpy(record.bssid, ap_record.bssid, 6);
+            memcpy(record.bssid, best_ap->bssid, 6);
             connect_queue_.push_back(record);
         }
     }
@@ -221,11 +226,9 @@ void WifiStation::StartConnect() {
     bzero(&wifi_config, sizeof(wifi_config));
     strcpy((char *)wifi_config.sta.ssid, ap_record.ssid.c_str());
     strcpy((char *)wifi_config.sta.password, ap_record.password.c_str());
-    if (remember_bssid_) {
-        wifi_config.sta.channel = ap_record.channel;
-        memcpy(wifi_config.sta.bssid, ap_record.bssid, 6);
-        wifi_config.sta.bssid_set = true;
-    }
+    wifi_config.sta.channel = ap_record.channel;
+    memcpy(wifi_config.sta.bssid, ap_record.bssid, 6);
+    wifi_config.sta.bssid_set = true;
     wifi_config.sta.listen_interval = 10;
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
 

--- a/wifi_station.cc
+++ b/wifi_station.cc
@@ -176,8 +176,10 @@ void WifiStation::HandleScanResult() {
 
     for (const auto& ssid_item : ssid_list) {
         wifi_ap_record_t *best_ap = nullptr;
+        int same_ssid_count = 0;
         for (int i = 0; i < ap_num; i++) {
             if (strcmp((char *)ap_records[i].ssid, ssid_item.ssid.c_str()) == 0) {
+                same_ssid_count++;
                 if (best_ap == nullptr || ap_records[i].rssi > best_ap->rssi) {
                     best_ap = &ap_records[i];
                 }
@@ -197,6 +199,7 @@ void WifiStation::HandleScanResult() {
                 .bssid = {0}
             };
             memcpy(record.bssid, best_ap->bssid, 6);
+            record.has_multiple_same_ssid = (same_ssid_count > 1);
             connect_queue_.push_back(record);
         }
     }
@@ -226,9 +229,19 @@ void WifiStation::StartConnect() {
     bzero(&wifi_config, sizeof(wifi_config));
     strcpy((char *)wifi_config.sta.ssid, ap_record.ssid.c_str());
     strcpy((char *)wifi_config.sta.password, ap_record.password.c_str());
-    wifi_config.sta.channel = ap_record.channel;
-    memcpy(wifi_config.sta.bssid, ap_record.bssid, 6);
-    wifi_config.sta.bssid_set = true;
+
+    // If remember_bssid_ is enabled and there's only one AP with this SSID, use remembered BSSID
+    // If there are multiple APs with same SSID (mesh/dual-band), connect to strongest signal
+    if (remember_bssid_ && !ap_record.has_multiple_same_ssid) {
+        wifi_config.sta.channel = ap_record.channel;
+        memcpy(wifi_config.sta.bssid, ap_record.bssid, 6);
+        wifi_config.sta.bssid_set = true;
+    } else {
+        if (ap_record.has_multiple_same_ssid) {
+            ESP_LOGI(TAG, "Multiple APs with same SSID found, connecting to strongest signal");
+        }
+        wifi_config.sta.bssid_set = false;
+    }
     wifi_config.sta.listen_interval = 10;
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
 


### PR DESCRIPTION
## Summary
When `remember_bssid_` is enabled and there are multiple APs with the same SSID (e.g., mesh network or dual-band router), connect to the one with the strongest signal instead of using the remembered BSSID which may have weaker signal.

## Changes

### `include/wifi_station.h`
Added `has_multiple_same_ssid` field to `WifiApRecord` struct to track if multiple APs with the same SSID were found during scan.

### `wifi_station.cc`

**`HandleScanResult()`**:
- Count how many APs with the same SSID name exist during scan
- Pass this info via `has_multiple_same_ssid` flag

**`StartConnect()`**:
- If `remember_bssid_` is enabled AND only one AP with this SSID exists → use remembered BSSID (original behavior)
- If `remember_bssid_` is enabled AND multiple APs with same SSID exist → connect to strongest signal (new behavior)
- If `remember_bssid_` is disabled → connect to strongest signal (unchanged)

## Use Case
Useful for mesh networks or dual-band routers where you want to remember the WiFi credentials but always connect to the strongest available AP with that SSID.