### PR TITLE
enable ESP-IDF version 6.0+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,40 @@
-idf_component_register(
-    SRCS
-        "wifi_manager.cc"
-        "wifi_configuration_ap.cc"
-        "wifi_station.cc"
-        "ssid_manager.cc"
-        "dns_server.cc"
-    INCLUDE_DIRS
-        "include"
-    EMBED_TXTFILES
-        "assets/wifi_configuration.html"
-        "assets/wifi_configuration_done.html"
-    REQUIRES
-    	"esp_timer"
-        "esp_http_server"
-        "esp_wifi"
-        "nvs_flash"
-        "json"
-)
+message("78/esp_wifi_connect: IDF_VER is ${IDF_VER}")
+
+if(${IDF_VER} STRGREATER_EQUAL "v6.0")
+    # v6
+    message("78/esp_wifi_connect: idf_component_register for v6 used")
+
+    idf_component_register(
+        SRCS
+            "wifi_manager.cc"
+            "wifi_configuration_ap.cc"
+            "wifi_station.cc"
+            "ssid_manager.cc"
+            "dns_server.cc"
+        INCLUDE_DIRS
+            "include"
+        EMBED_TXTFILES
+            "assets/wifi_configuration.html"
+            "assets/wifi_configuration_done.html"
+        REQUIRES "esp_timer" "esp_http_server" "esp_wifi" "nvs_flash"
+    )
+else()
+    # v5
+    message("78/esp_wifi_connect: idf_component_register for v5 used")
+
+    idf_component_register(
+        SRCS
+            "wifi_manager.cc"
+            "wifi_configuration_ap.cc"
+            "wifi_station.cc"
+            "ssid_manager.cc"
+            "dns_server.cc"
+        INCLUDE_DIRS
+            "include"
+        EMBED_TXTFILES
+            "assets/wifi_configuration.html"
+            "assets/wifi_configuration_done.html"
+        REQUIRES "esp_timer" "esp_http_server" "esp_wifi" "nvs_flash" "json"
+    )
+endif()
+

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,5 +1,9 @@
 dependencies:
   idf: '>=5.3'
+  espressif/cjson:
+    version: "^1.7.19"
+    matches:
+      - if: "idf_version >=6.0"
 description: ESP32 WiFi Configuration
 files:
   exclude:


### PR DESCRIPTION
In ESP-IDF version 6 there is no built-in JSON any more.
To make this component compile in ESP-IDF version 6.0+, the built-in JSON component has to be removed according to ESP-IDF 6.x Migration Guide / Migration from 5.5 to 6.0 / Protocols / JSON
The changes in this pull request allow to use this component  in ESP-IDF version 5 AND version 6.