### PR TITLE
fix(wifi): retry first-attempt association with delay; cancel in-flight connect on timeout

### DIFF
--- a/wifi_configuration_ap.cc
+++ b/wifi_configuration_ap.cc
@@ -689,45 +689,112 @@ bool WifiConfigurationAp::ConnectToWifi(const std::string &ssid, const std::stri
     }
     
     is_connecting_ = true;
-    esp_wifi_scan_stop();
-    xEventGroupClearBits(event_group_, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT);
 
-    wifi_config_t wifi_config;
-    bzero(&wifi_config, sizeof(wifi_config));
-    strlcpy((char *)wifi_config.sta.ssid, ssid.c_str(), 32);
-    strlcpy((char *)wifi_config.sta.password, password.c_str(), 64);
-    wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
-    wifi_config.sta.failure_retry_cnt = 1;
-    
-    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
-    auto ret = esp_wifi_connect();
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to connect to WiFi: %d", ret);
-        is_connecting_ = false;
-        return false;
-    }
-    ESP_LOGI(TAG, "Connecting to WiFi %s", ssid.c_str());
+    // Upper-level retry loop with delay between attempts.
+    //
+    // Background: in APSTA mode the captive-portal session is on the AP
+    // beacon channel (typically 1), and the target home AP is on some
+    // other channel (e.g. 10). When ConnectToWifi triggers, esp-wifi
+    // performs a Channel Switch Announcement to move both AP and STA to
+    // the home AP's channel, then immediately issues an association
+    // request. The home AP frequently responds with "Association
+    // Response status=30 (Refused Temporarily)" + a Comeback Time in
+    // TUs (= ~1.1s for Buffalo routers, observed) because its own
+    // state hasn't settled yet for the new station.
+    //
+    // The ESP-IDF wifi driver's failure_retry_cnt issues re-association
+    // attempts back-to-back (within a few ms) and does not honor the
+    // 802.11 Comeback Time, so every driver-internal retry is refused
+    // the same way and the first ConnectToWifi() call returns failure.
+    // By the time the user clicks "submit" a second time (~8s later)
+    // the AP has fully settled and association succeeds on the first
+    // try — which is why users observe "it always fails the first
+    // time, then works".
+    //
+    // Fix: when an attempt fails, wait long enough for the comeback
+    // timer + AP state settle (~3s is safe), then retry once. This
+    // produces a single user-visible success path instead of forcing
+    // the user to resubmit. The driver-internal retries (set below
+    // via failure_retry_cnt) are kept as a secondary safety net.
+    constexpr int kMaxAttempts = 2;
+    constexpr int kRetryDelayMs = 3000;
+    bool connected = false;
 
-    // Wait for the connection to complete for 10 or 25 seconds
-    EventBits_t bits = xEventGroupWaitBits(
-        event_group_,
-        WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
-        pdTRUE,
-        pdFALSE,
+    for (int attempt = 1; attempt <= kMaxAttempts && !connected; ++attempt) {
+        if (attempt > 1) {
+            ESP_LOGI(TAG,
+                "WiFi attempt %d/%d after %d ms delay "
+                "(waiting for AP comeback timer + state settle)",
+                attempt, kMaxAttempts, kRetryDelayMs);
+            vTaskDelay(pdMS_TO_TICKS(kRetryDelayMs));
+        }
+
+        xEventGroupClearBits(event_group_, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT);
+        esp_wifi_scan_stop();
+
+        wifi_config_t wifi_config;
+        bzero(&wifi_config, sizeof(wifi_config));
+        strlcpy((char *)wifi_config.sta.ssid, ssid.c_str(), 32);
+        strlcpy((char *)wifi_config.sta.password, password.c_str(), 64);
+        wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+        wifi_config.sta.failure_retry_cnt = 1;
+
+        ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+        auto ret = esp_wifi_connect();
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG,
+                "esp_wifi_connect failed: %d (attempt %d/%d)",
+                ret, attempt, kMaxAttempts);
+            continue;
+        }
+        ESP_LOGI(TAG, "Connecting to WiFi %s (attempt %d/%d)",
+            ssid.c_str(), attempt, kMaxAttempts);
+
+        // Wait for the connection to complete for 10 or 25 seconds.
+        EventBits_t bits = xEventGroupWaitBits(
+            event_group_,
+            WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+            pdTRUE,
+            pdFALSE,
 #ifdef CONFIG_SOC_WIFI_SUPPORT_5G
-        pdMS_TO_TICKS(25000)
+            pdMS_TO_TICKS(25000)
 #else
-        pdMS_TO_TICKS(10000)
+            pdMS_TO_TICKS(10000)
 #endif
-    );
+        );
+
+        if (bits & WIFI_CONNECTED_BIT) {
+            connected = true;
+        } else {
+            const bool timed_out = (bits == 0);
+            if (timed_out) {
+                // Timeout — neither WIFI_CONNECTED_BIT nor WIFI_FAIL_BIT
+                // was set, so WIFI_EVENT_STA_DISCONNECTED has not fired
+                // and the driver may still be in `connecting` state.
+                // Cancel the in-flight attempt explicitly before the
+                // retry delay; without this the next esp_wifi_connect()
+                // can return ESP_ERR_WIFI_STATE on a connecting-state
+                // driver (per esp_wifi.h attention 3), making the retry
+                // a no-op on slow / event-dropping APs.
+                esp_wifi_disconnect();
+            }
+            ESP_LOGW(TAG,
+                "Attempt %d/%d %s%s",
+                attempt, kMaxAttempts,
+                timed_out ? "timed out (driver may still be connecting)" : "failed",
+                attempt < kMaxAttempts ? " — will retry" : "");
+        }
+    }
     is_connecting_ = false;
 
-    if (bits & WIFI_CONNECTED_BIT) {
+    if (connected) {
         ESP_LOGI(TAG, "Connected to WiFi %s", ssid.c_str());
         esp_wifi_disconnect();
         return true;
     } else {
-        ESP_LOGE(TAG, "Failed to connect to WiFi %s", ssid.c_str());
+        ESP_LOGE(TAG,
+            "Failed to connect to WiFi %s after %d attempts",
+            ssid.c_str(), kMaxAttempts);
         return false;
     }
 }


### PR DESCRIPTION
## Summary

When `ConnectToWifi()` is invoked in APSTA mode, the home AP often refuses the first association with `status=30 "Refused Temporarily"` and a Comeback Time (~1.1s on Buffalo routers) because the AP hasn't settled state for the new station yet. The ESP-IDF wifi driver's `failure_retry_cnt` issues retries back-to-back without honoring the 802.11 Comeback Time, so every driver-internal retry hits the same refusal and the first `ConnectToWifi()` call returns failure — users observe "it always fails the first time, then works on resubmit".

This PR adds an upper-level retry loop that waits ~3s between attempts (giving the AP time to settle), plus an explicit `esp_wifi_disconnect()` on the `bits == 0` timeout branch so the driver isn't left mid-connect when the next `esp_wifi_connect()` fires (avoiding `ESP_ERR_WIFI_STATE` per `esp_wifi.h` attention 3).

Full background, verification logs, and limitations are in the commit message.

## Origin

This fix was originally contributed by @maha0525 to a downstream project that vendors `78__esp-wifi-connect` as a component:

- Downstream PR: kisaragi-mochi/stackchan-mcp#186
- Author preserved as `Maha <mahomu.tript013@gmail.com>` via `--author`, matching the commit metadata of the merged downstream PR. If a privacy-safer noreply form is preferred for the upstream record, we're happy to re-author the commit on request.

@maha0525 explicitly offered to have this mirrored upstream with that credit format, in the downstream review thread. Happy to adjust the wording / commit shape / line wrapping to match this repo's conventions — please let us know what works best.

## Verification

Confirmed on M5Stack CoreS3 (stackchan board) against a Buffalo Buffalo-G-E640 router (WPA2-PSK, channel 10):

- Attempt 1: Association refused temporarily, comeback time 1124 TUs → 4 driver-internal retries within ~150ms, all refused
- 3000ms delay
- Attempt 2: auth → assoc → run, connected in ~3s

Only one AP model has been verified so far. The underlying 802.11 spec allows any compliant router to defer association similarly (especially with MFP / 802.11w enabled), so the fix should help broadly. Environments where the first attempt already succeeds are unaffected (the retry loop is not entered).

## Notes for the maintainer

- 1 commit, 1 file (`wifi_configuration_ap.cc`), +97/-30.
- No new dependencies / Kconfig options.
- Behavioral envelope: adds a 3s sleep + 1 retry only on first-attempt failure; behavior on the success path is unchanged.
- License: this repo does not currently carry a `LICENSE` file. We're happy to follow whatever license applies to the rest of the repo; please let us know if any header note should be added to the changed file.

Thanks for considering!