### PR TITLE
支持主机名设置,让路由器DHCP显示自定义名称,而不是espressif

### DIFF
--- a/include/wifi_manager.h
+++ b/include/wifi_manager.h
@@ -50,6 +50,7 @@ struct WifiManagerConfig {
     // Station mode scan interval with exponential backoff
     int station_scan_min_interval_seconds = 10;   // Initial scan interval (fast retry)
     int station_scan_max_interval_seconds = 300;  // Maximum scan interval (5 minutes)
+    std::string station_hostname;                  // Optional DHCP hostname for station mode
 
     // How many times to retry the strongest same-SSID AP before falling back to
     // a weaker one (requires WIFI_ALL_CHANNEL_SCAN, which is the default when

--- a/include/wifi_station.h
+++ b/include/wifi_station.h
@@ -56,6 +56,7 @@ public:
     void OnDisconnected(std::function<void(int reason)> on_disconnected);
     void OnScanBegin(std::function<void()> on_scan_begin);
     void SetScanIntervalRange(int min_interval_seconds, int max_interval_seconds);
+    void SetHostname(const std::string& hostname) { hostname_ = hostname; }
 
     // How many times to retry the strongest same-SSID AP before falling back to
     // a weaker one. Only effective when remember_bssid is off (default). A value
@@ -72,6 +73,7 @@ private:
     std::string ssid_;
     std::string password_;
     std::string ip_address_;
+    std::string hostname_;
     int8_t max_tx_power_;
     uint8_t remember_bssid_;
     uint8_t failure_retry_cnt_ = 3;  // Retries on strongest AP before falling back

--- a/wifi_manager.cc
+++ b/wifi_manager.cc
@@ -137,6 +137,7 @@ void WifiManager::StartStation() {
     station_->SetScanIntervalRange(config_.station_scan_min_interval_seconds,
                                    config_.station_scan_max_interval_seconds);
     station_->SetFailureRetryCnt(config_.station_failure_retry_cnt);
+    station_->SetHostname(config_.station_hostname);
 
     // Setup callbacks
     station_->OnScanBegin([this]() {

--- a/wifi_station.cc
+++ b/wifi_station.cc
@@ -121,6 +121,14 @@ void WifiStation::Start() {
     
     // Create the default WiFi station interface
     station_netif_ = esp_netif_create_default_wifi_sta();
+    if (!hostname_.empty()) {
+        esp_err_t err = esp_netif_set_hostname(station_netif_, hostname_.c_str());
+        if (err == ESP_OK) {
+            ESP_LOGI(TAG, "Station DHCP hostname: %s", hostname_.c_str());
+        } else {
+            ESP_LOGW(TAG, "Failed to set station DHCP hostname: %s", esp_err_to_name(err));
+        }
+    }
 
     ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT,
                                                         ESP_EVENT_ANY_ID,


### PR DESCRIPTION
<img width="624" height="54" alt="image" src="https://github.com/user-attachments/assets/3f3bd2fa-4673-41ab-b520-0733e2cd6e87" />

ESP32没设置的时候，默认是espressif；加了个接口